### PR TITLE
fix: escape `categories` query

### DIFF
--- a/api/index.php
+++ b/api/index.php
@@ -77,7 +77,7 @@ if(isset($_GET["dev"])){
 $categories = false;
 $API_ENDPOINT .= "posts?_embed";
 if(isset($_GET["categories"]) && !empty($_GET["categories"])){
-    $API_ENDPOINT .= "&categories={$_GET['categories']}";
+    $API_ENDPOINT .= "&categories=".urlencode($_GET['categories']);
     $categories = $_GET["categories"];
 }
 


### PR DESCRIPTION
## What
クエリパラメータをエスケープしてURLを組み立てるようにする

## Why
クエリパラメータをエスケープせずにURLを組み立てているため、任意のクエリパラメータを挿入できる
(なお、本件は一般公開されているURLに認証なしでアクセスしているため、脆弱ではあるがこれによる被害はない)